### PR TITLE
Add cyan progress bar and fleet scanning helper

### DIFF
--- a/githarborops/utils/display_utils/progress.py
+++ b/githarborops/utils/display_utils/progress.py
@@ -1,9 +1,17 @@
 """Progress indicators for long-running tasks."""
 
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Iterator, Sequence, Tuple
 
-from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.progress import (
+    BarColumn,
+    Progress,
+    ProgressColumn,
+    SpinnerColumn,
+    Task,
+    TextColumn,
+)
+from rich.text import Text
 
 
 @contextmanager
@@ -18,3 +26,42 @@ def spinner(message: str) -> Iterator[None]:
     finally:
         progress.stop_task(task_id)
         progress.stop()
+
+
+class _CompletionColumn(ProgressColumn):
+    """Render a green check mark when a task finishes."""
+
+    def render(self, task: Task) -> Text:  # type: ignore[override]
+        return Text("✔", style="green") if task.finished else Text("")
+
+
+@contextmanager
+def progress_bar(total: int, message: str) -> Iterator[Tuple[Progress, int]]:
+    """Context manager providing a styled progress bar.
+
+    The bar shows cyan progress on a navy background and turns green on
+    completion with a check mark.
+    """
+
+    with Progress(
+        TextColumn("{task.description}"),
+        BarColumn(
+            bar_width=None,
+            complete_style="cyan",
+            style="navy_blue",
+            finished_style="green",
+        ),
+        TextColumn("{task.percentage:>3.0f}%"),
+        _CompletionColumn(),
+    ) as progress:
+        task_id = progress.add_task(message, total=total)
+        yield progress, task_id
+
+
+def scanning_fleet(repositories: Sequence[str]) -> Iterator[str]:
+    """Iterate repositories while displaying a scanning progress bar."""
+
+    with progress_bar(len(repositories), "Scanning fleet...") as (progress, task_id):
+        for repo in repositories:
+            yield repo
+            progress.advance(task_id)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,16 @@
+from githarborops.utils.display_utils import progress
+from rich.progress import BarColumn
+
+
+def test_progress_bar_styling():
+    with progress.progress_bar(1, "Test") as (p, task_id):
+        bar_col = next(col for col in p.columns if isinstance(col, BarColumn))
+        assert bar_col.complete_style == "cyan"
+        assert bar_col.style == "navy_blue"
+        assert bar_col.finished_style == "green"
+        assert any(isinstance(col, progress._CompletionColumn) for col in p.columns)
+
+
+def test_scanning_fleet_iterates():
+    repos = ["a", "b", "c"]
+    assert list(progress.scanning_fleet(repos)) == repos


### PR DESCRIPTION
## Summary
- add styled progress bar helper with cyan progress, navy background, and green completion tick
- provide `scanning_fleet` helper to show progress over multiple repositories
- test progress bar styling and fleet scanning iterator

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a73c586eb0832781a9f96645ee048c