### PR TITLE
feat: update display severity colors

### DIFF
--- a/githarborops/utils/display_utils/colors.py
+++ b/githarborops/utils/display_utils/colors.py
@@ -2,23 +2,30 @@
 
 from rich.style import Style
 
-# Base colors
-BLUE = Style(color="blue")
-CYAN = Style(color="cyan")
-GREEN = Style(color="green")
-YELLOW = Style(color="yellow")
-RED = Style(color="red")
-MAGENTA = Style(color="magenta")
+# Severity and general output styles
+#
+# DEFAULT   – Bright white, used for general text
+# INFO      – Deep navy
+# DETAILS   – Sea blue/teal
+# SUCCESS   – Harbor green
+# WARN      – Yellow
+# ERROR     – Bright red
+# HIGHLIGHT – Bold cyan
 
-# Severity styles
-INFO = CYAN
-WARN = Style(color="yellow", bold=True)
-ERROR = Style(color="red", bold=True)
-SUCCESS = Style(color="green", bold=True)
+DEFAULT = Style(color="bright_white")
+INFO = Style(color="#001f3f")
+DETAILS = Style(color="#17a2b8")
+SUCCESS = Style(color="#21a179")
+WARN = Style(color="yellow")
+ERROR = Style(color="#ff4136")
+HIGHLIGHT = Style(color="cyan", bold=True)
 
 SEVERITY = {
     "info": INFO,
+    "details": DETAILS,
+    "success": SUCCESS,
     "warn": WARN,
     "error": ERROR,
-    "success": SUCCESS,
+    "highlight": HIGHLIGHT,
 }
+


### PR DESCRIPTION
## Summary
- add constants for default, info, details, success, warn, error, and highlight CLI colors
- expose these styles via a SEVERITY lookup map

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a73c5de2648327976f1e729f628a03