### PR TITLE
style: standardize interactive menu styling

### DIFF
--- a/githarborops/utils/display_utils/menu.py
+++ b/githarborops/utils/display_utils/menu.py
@@ -1,20 +1,57 @@
 """Interactive menu helpers built on questionary."""
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Union
 
 import questionary
+from questionary import Choice, Style
 
 
-def select_repo(repos: Iterable[str]) -> Optional[str]:
+ANCHOR_ICON = "⚓"
+MENU_STYLE = Style(
+    [
+        ("qmark", "fg:#00ffff bold"),
+        ("question", "fg:#00ffff bold"),
+        ("answer", "fg:#00ffff bold"),
+        ("pointer", "fg:#00ffff bold"),
+        ("highlighted", "fg:#00ffff bold"),
+        ("selected", "fg:#00ffff bold"),
+        ("text", "fg:#ffffff"),
+        ("disabled", "fg:#888888"),
+    ]
+)
+
+ChoiceType = Union[str, Choice]
+
+
+def menu_select(title: str, choices: Iterable[ChoiceType]) -> Optional[str]:
+    """Standard menu selection prompt with GitHarborOps styling."""
+    return questionary.select(
+        title, choices=list(choices), qmark=ANCHOR_ICON, style=MENU_STYLE
+    ).ask()
+
+
+def menu_confirm(message: str) -> bool:
+    """Standard confirmation prompt with GitHarborOps styling."""
+    return bool(
+        questionary.confirm(message, qmark=ANCHOR_ICON, style=MENU_STYLE).ask()
+    )
+
+
+def githarborops_menu(options: Iterable[ChoiceType]) -> Optional[str]:
+    """Display the GitHarborOps main menu."""
+    return menu_select("GitHarborOps Menu", options)
+
+
+def select_repo(repos: Iterable[ChoiceType]) -> Optional[str]:
     """Prompt the user to choose a repository from *repos*."""
-    return questionary.select("Select repository", choices=list(repos)).ask()
+    return menu_select("Select repository", repos)
 
 
-def select_action(actions: Iterable[str]) -> Optional[str]:
+def select_action(actions: Iterable[ChoiceType]) -> Optional[str]:
     """Prompt the user to choose an action from *actions*."""
-    return questionary.select("Select action", choices=list(actions)).ask()
+    return menu_select("Select action", actions)
 
 
 def confirm(message: str) -> bool:
     """Yes/No confirmation prompt."""
-    return bool(questionary.confirm(message).ask())
+    return menu_confirm(message)

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,54 @@
+import questionary
+
+from githarborops.utils.display_utils import menu
+
+
+class DummyQuestion:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def ask(self):
+        return "choice"
+
+
+def test_menu_select_uses_anchor_and_style(monkeypatch):
+    captured = {}
+
+    def mock_select(message, **kwargs):
+        captured["message"] = message
+        captured["kwargs"] = kwargs
+        return DummyQuestion(**kwargs)
+
+    monkeypatch.setattr(questionary, "select", mock_select)
+
+    assert menu.menu_select("Title", ["a"]) == "choice"
+    assert captured["kwargs"]["qmark"] == menu.ANCHOR_ICON
+    assert captured["kwargs"]["style"] is menu.MENU_STYLE
+
+
+def test_menu_confirm_uses_anchor_and_style(monkeypatch):
+    captured = {}
+
+    def mock_confirm(message, **kwargs):
+        captured["message"] = message
+        captured["kwargs"] = kwargs
+        return DummyQuestion(**kwargs)
+
+    monkeypatch.setattr(questionary, "confirm", mock_confirm)
+
+    assert menu.menu_confirm("Proceed?")
+    assert captured["kwargs"]["qmark"] == menu.ANCHOR_ICON
+    assert captured["kwargs"]["style"] is menu.MENU_STYLE
+
+
+def test_githarborops_menu_calls_select(monkeypatch):
+    called = {}
+
+    def mock_select(message, **kwargs):
+        called["message"] = message
+        return DummyQuestion(**kwargs)
+
+    monkeypatch.setattr(questionary, "select", mock_select)
+
+    menu.githarborops_menu(["opt"])
+    assert called["message"] == "GitHarborOps Menu"


### PR DESCRIPTION
## Summary
- style questionary prompts with bold cyan ⚓ titles
- centralize menu helpers and GitHarborOps menu
- test new menu helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73c5bb1488327a30e6c67e9d5dea4