### PR TITLE
feat: add nautical notifications

### DIFF
--- a/githarborops/utils/display_utils/colors.py
+++ b/githarborops/utils/display_utils/colors.py
@@ -9,6 +9,7 @@ GREEN = Style(color="green")
 YELLOW = Style(color="yellow")
 RED = Style(color="red")
 MAGENTA = Style(color="magenta")
+HARBOR_NAVY = Style(color="#001f3f")
 
 # Severity styles
 INFO = CYAN

--- a/githarborops/utils/display_utils/notifications.py
+++ b/githarborops/utils/display_utils/notifications.py
@@ -7,25 +7,35 @@ from . import colors
 console = Console()
 
 
-def _notify(message: str, level: str) -> None:
-    style = colors.SEVERITY.get(level)
+NAUTICAL_PREFIXES = {
+    "success": "Anchors aweigh! ",
+    "warn": "Batten down the hatches! ",
+    "error": "Mayday! ",
+    "info": "Captain's log: ",
+}
+
+
+def _notify(message: str, level: str, style=None) -> None:
+    """Render a styled notification with a nautical flavor."""
+    prefix = NAUTICAL_PREFIXES.get(level, "")
+    style = style or colors.SEVERITY.get(level)
     if style:
-        console.print(message, style=style)
+        console.print(f"{prefix}{message}", style=style)
     else:
-        console.print(message)
+        console.print(f"{prefix}{message}")
 
 
 def notify_info(message: str) -> None:
-    _notify(message, "info")
+    _notify(message, "info", colors.HARBOR_NAVY)
 
 
 def notify_warn(message: str) -> None:
-    _notify(message, "warn")
+    _notify(message, "warn", colors.HARBOR_NAVY)
 
 
 def notify_error(message: str) -> None:
-    _notify(message, "error")
+    _notify(message, "error", colors.HARBOR_NAVY)
 
 
 def notify_success(message: str) -> None:
-    _notify(message, "success")
+    _notify(message, "success", colors.HARBOR_NAVY)


### PR DESCRIPTION
## Summary
- add Harbor Navy base color to display utils
- prefix notifications with nautical phrases and use Harbor Navy color

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73c59ada48327b96165d2a78776e7