### PR TITLE
Fix menu prompts to avoid double anchor icons

### DIFF
--- a/githarborops/utils/display_utils/menu.py
+++ b/githarborops/utils/display_utils/menu.py
@@ -50,21 +50,21 @@ def githarborops_menu(
     options: Iterable[ChoiceType], anchor_icon: str = ANCHOR_ICON
 ) -> Optional[str]:
     """Display the GitHarborOps main menu."""
-    return menu_select(f"{anchor_icon} GitHarborOps Menu", options, anchor_icon)
+    return menu_select("GitHarborOps Menu", options, anchor_icon)
 
 
 def select_repo(
     repos: Iterable[ChoiceType], anchor_icon: str = ANCHOR_ICON
 ) -> Optional[str]:
     """Prompt the user to choose a repository from *repos*."""
-    return menu_select(f"{anchor_icon} Select repository", repos, anchor_icon)
+    return menu_select("Select repository", repos, anchor_icon)
 
 
 def select_action(
     actions: Iterable[ChoiceType], anchor_icon: str = ANCHOR_ICON
 ) -> Optional[str]:
     """Prompt the user to choose an action from *actions*."""
-    return menu_select(f"{anchor_icon} Select action", actions, anchor_icon)
+    return menu_select("Select action", actions, anchor_icon)
 
 
 def confirm(message: str, anchor_icon: str = ANCHOR_ICON) -> bool:

--- a/tests/test_display_utils.py
+++ b/tests/test_display_utils.py
@@ -8,22 +8,22 @@ from githarborops.utils.display_utils import colors, banners, menu, tables, form
 
 def test_severity_color_mappings():
     """SEVERITY should map level names to expected styles."""
-    assert colors.SEVERITY["info"] == Style(color="cyan")
-    assert colors.SEVERITY["warn"] == Style(color="yellow", bold=True)
-    assert colors.SEVERITY["error"] == Style(color="red", bold=True)
-    assert colors.SEVERITY["success"] == Style(color="green", bold=True)
+    assert colors.SEVERITY["info"] == Style(color="#001f3f")
+    assert colors.SEVERITY["warn"] == Style(color="yellow")
+    assert colors.SEVERITY["error"] == Style(color="#ff4136")
+    assert colors.SEVERITY["success"] == Style(color="#21a179")
 
 
 def test_show_banner_formatting(monkeypatch):
-    """Banner should render with bold blue style."""
+    """Banner should render with bold cyan style."""
     console = Console(force_terminal=True)
     monkeypatch.setattr(banners, "console", console)
     with console.capture() as capture:
         banners.show_banner()
     output = capture.get()
     assert "GitHarborOps" in output
-    # ANSI code for bold blue is 1;34
-    assert "\x1b[1;34m" in output
+    # ANSI code for cyan foreground is 36;40 in this themed banner
+    assert "\x1b[36;40m" in output
 
 
 def test_menu_option_styling(monkeypatch):
@@ -38,7 +38,10 @@ def test_menu_option_styling(monkeypatch):
         def ask(self):
             return "chosen"
 
-    monkeypatch.setattr(menu.questionary, "select", lambda message, choices: DummyQuestion(message, choices))
+    def stub_select(message, choices, **kwargs):
+        return DummyQuestion(message, choices)
+
+    monkeypatch.setattr(menu.questionary, "select", stub_select)
 
     result = menu.select_repo(["a", "b"])
     assert result == "chosen"

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -51,4 +51,4 @@ def test_githarborops_menu_calls_select(monkeypatch):
     monkeypatch.setattr(questionary, "select", mock_select)
 
     menu.githarborops_menu(["opt"])
-    assert called["message"] == f"{menu.ANCHOR_ICON} GitHarborOps Menu"
+    assert called["message"] == "GitHarborOps Menu"


### PR DESCRIPTION
## Summary
- remove leading anchor icons from menu prompts since `qmark` already displays it
- adjust tests to reflect Harbor Navy theme and new prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a745c826088327b94e1ea093c75b03