### PR TITLE
Handle single repo selection

### DIFF
--- a/githarborops/main.py
+++ b/githarborops/main.py
@@ -34,7 +34,12 @@ def main():
         sys.exit(1)
 
     # Select a repo
-    repo_path = menu.select_repo(repos)
+    if len(repos) == 1:
+        repo_path = repos[0]
+    else:
+        repo_path = menu.select_repo(
+            repos, instruction="Use arrow keys and press Enter to select"
+        )
 
     if not repo_path:
         print("No repository selected. Exiting.")

--- a/githarborops/utils/display_utils/menu.py
+++ b/githarborops/utils/display_utils/menu.py
@@ -29,6 +29,7 @@ def menu_select(
     title: str,
     choices: Iterable[ChoiceType],
     anchor_icon: str = ANCHOR_ICON,
+    instruction: Optional[str] = None,
 ) -> Optional[str]:
     """Standard menu selection prompt with GitHarborOps Harbor Navy styling."""
     return questionary.select(
@@ -36,6 +37,7 @@ def menu_select(
         choices=list(choices),
         qmark=anchor_icon,
         style=MENU_STYLE,
+        instruction=instruction,
     ).ask()
 
 
@@ -54,10 +56,14 @@ def githarborops_menu(
 
 
 def select_repo(
-    repos: Iterable[ChoiceType], anchor_icon: str = ANCHOR_ICON
+    repos: Iterable[ChoiceType],
+    anchor_icon: str = ANCHOR_ICON,
+    instruction: Optional[str] = None,
 ) -> Optional[str]:
     """Prompt the user to choose a repository from *repos*."""
-    return menu_select(f"{anchor_icon} Select repository", repos, anchor_icon)
+    return menu_select(
+        f"{anchor_icon} Select repository", repos, anchor_icon, instruction
+    )
 
 
 def select_action(

--- a/tests/test_display_utils.py
+++ b/tests/test_display_utils.py
@@ -8,10 +8,10 @@ from githarborops.utils.display_utils import colors, banners, menu, tables, form
 
 def test_severity_color_mappings():
     """SEVERITY should map level names to expected styles."""
-    assert colors.SEVERITY["info"] == Style(color="cyan")
-    assert colors.SEVERITY["warn"] == Style(color="yellow", bold=True)
-    assert colors.SEVERITY["error"] == Style(color="red", bold=True)
-    assert colors.SEVERITY["success"] == Style(color="green", bold=True)
+    assert colors.SEVERITY["info"] == colors.INFO
+    assert colors.SEVERITY["warn"] == colors.WARN
+    assert colors.SEVERITY["error"] == colors.ERROR
+    assert colors.SEVERITY["success"] == colors.SUCCESS
 
 
 def test_show_banner_formatting(monkeypatch):
@@ -22,8 +22,8 @@ def test_show_banner_formatting(monkeypatch):
         banners.show_banner()
     output = capture.get()
     assert "GitHarborOps" in output
-    # ANSI code for bold blue is 1;34
-    assert "\x1b[1;34m" in output
+    # ANSI code for cyan foreground should be present
+    assert "\x1b[36" in output
 
 
 def test_menu_option_styling(monkeypatch):
@@ -38,11 +38,15 @@ def test_menu_option_styling(monkeypatch):
         def ask(self):
             return "chosen"
 
-    monkeypatch.setattr(menu.questionary, "select", lambda message, choices: DummyQuestion(message, choices))
+    monkeypatch.setattr(
+        menu.questionary,
+        "select",
+        lambda message, choices, **kwargs: DummyQuestion(message, choices),
+    )
 
     result = menu.select_repo(["a", "b"])
     assert result == "chosen"
-    assert captured == {"message": "Select repository", "choices": ["a", "b"]}
+    assert captured == {"message": "⚓ Select repository", "choices": ["a", "b"]}
 
 
 def test_table_row_alternation(monkeypatch):


### PR DESCRIPTION
## Summary
- Skip selection menu when only one repo is discovered, otherwise show an instruction when choosing a repo
- Add optional instruction support to menu helpers
- Refresh display utility tests for Harbor Navy theme and updated menu API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a745c46fe88327a8294320c7defa1d